### PR TITLE
feat: Implement Role-Based Access Control (RBAC) for Marketplace Contract

### DIFF
--- a/src/constants.cairo
+++ b/src/constants.cairo
@@ -1,0 +1,6 @@
+/// Roles
+pub const DEFAULT_ADMIN_ROLE: felt252 = selector!("DEFAULT_ADMIN_ROLE");
+pub const MARKETPLACE_ADMIN_ROLE: felt252 = selector!("MARKETPLACE_ADMIN_ROLE");
+pub const COLLECTION_CREATOR_ROLE: felt252 = selector!("COLLECTION_CREATOR_ROLE");
+pub const PAUSER_ROLE: felt252 = selector!("PAUSER_ROLE");
+pub const VERIFIER_ROLE: felt252 = selector!("VERIFIER_ROLE");

--- a/src/interfaces/imarketplace.cairo
+++ b/src/interfaces/imarketplace.cairo
@@ -65,5 +65,16 @@ pub trait IMarketplace<TContractState> {
     fn get_listing(self: @TContractState, listing_id: u256) -> Listing;
     fn get_listing_status(self: @TContractState, listing_id: u256) -> ListingStatus;
     fn is_listing_active(self: @TContractState, listing_id: u256) -> bool;
+
+    fn pause_marketplace(ref self: TContractState);
+    fn unpause_marketplace(ref self: TContractState);
+
+    // Access control
+    fn grant_this_role(ref self: TContractState, role: felt252, account: ContractAddress);
+    fn revoke_this_role(ref self: TContractState, role: felt252, account: ContractAddress);
+    fn renounce_this_role(ref self: TContractState, role: felt252);
+    fn has_this_role(self: @TContractState, role: felt252, account: ContractAddress) -> bool;
+    fn get_this_role_admin(self: @TContractState, role: felt252) -> felt252;
+    fn get_this_role_member_count(self: @TContractState, role: felt252) -> u256;
 }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,6 +4,7 @@ pub mod NftMetadata;
 pub mod Offer;
 pub mod Ownership;
 pub mod VerifySignature;
+pub mod constants;
 pub mod interfaces {
     pub mod icollection_factory;
     pub mod ierc20;

--- a/tests/test_marketplace.cairo
+++ b/tests/test_marketplace.cairo
@@ -2,6 +2,7 @@ use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
     start_cheat_caller_address, stop_cheat_block_timestamp, stop_cheat_caller_address,
 };
+use starkbid_contract::constants::{DEFAULT_ADMIN_ROLE, MARKETPLACE_ADMIN_ROLE, PAUSER_ROLE};
 use starkbid_contract::interfaces::imarketplace::{
     IMarketplaceDispatcher, IMarketplaceDispatcherTrait, ListingStatus, ListingType,
 };
@@ -10,7 +11,9 @@ use starknet::{ContractAddress, contract_address_const, get_block_timestamp};
 // Helper to initialize contract
 fn init_contract() -> IMarketplaceDispatcher {
     let contract_class = declare("Marketplace").unwrap().contract_class();
-    let (contract_address, _) = contract_class.deploy(@array![]).unwrap();
+    let mut constructor_args: Array<felt252> = array![];
+    admin_address().serialize(ref constructor_args);
+    let (contract_address, _) = contract_class.deploy(@constructor_args).unwrap();
     IMarketplaceDispatcher { contract_address }
 }
 
@@ -25,6 +28,22 @@ fn buyer() -> ContractAddress {
 
 fn nft_contract() -> ContractAddress {
     contract_address_const::<54321>()
+}
+
+fn admin_address() -> ContractAddress {
+    contract_address_const::<99999>()
+}
+
+fn marketplace_admin() -> ContractAddress {
+    contract_address_const::<11111>()
+}
+
+fn pauser() -> ContractAddress {
+    contract_address_const::<22222>()
+}
+
+fn unauthorized_user() -> ContractAddress {
+    contract_address_const::<33333>()
 }
 
 #[test]
@@ -252,4 +271,394 @@ fn test_is_listing_active() {
 
     // Check inactive status
     assert(!contract.is_listing_active(listing_id), 'Should be inactive');
+}
+
+#[test]
+fn test_initial_admin_roles() {
+    let contract = init_contract();
+
+    // Verify admin has both DEFAULT_ADMIN_ROLE and MARKETPLACE_ADMIN_ROLE
+    assert(
+        contract.has_this_role(DEFAULT_ADMIN_ROLE, admin_address()), 'Admin missing default role'
+    );
+    assert(
+        contract.has_this_role(MARKETPLACE_ADMIN_ROLE, admin_address()),
+        'Admin missing marketplace role'
+    );
+
+    // Verify role member count
+    assert(contract.get_this_role_member_count(DEFAULT_ADMIN_ROLE) == 1, 'Wrong admin count');
+    assert(
+        contract.get_this_role_member_count(MARKETPLACE_ADMIN_ROLE) == 1,
+        'Wrong marketplace admin count'
+    );
+}
+
+#[test]
+fn test_role_hierarchy() {
+    let contract = init_contract();
+
+    // Verify role hierarchy - DEFAULT_ADMIN_ROLE should be admin of other roles
+    assert(
+        contract.get_this_role_admin(MARKETPLACE_ADMIN_ROLE) == DEFAULT_ADMIN_ROLE,
+        'Wrong marketplace admin role'
+    );
+    assert(
+        contract.get_this_role_admin(PAUSER_ROLE) == DEFAULT_ADMIN_ROLE, 'Wrong pauser admin role'
+    );
+}
+
+#[test]
+fn test_grant_role() {
+    let contract = init_contract();
+
+    // Grant MARKETPLACE_ADMIN_ROLE to marketplace_admin
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify role was granted
+    assert(contract.has_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin()), 'Role not granted');
+    assert(contract.get_this_role_member_count(MARKETPLACE_ADMIN_ROLE) == 2, 'Wrong member count');
+}
+
+#[test]
+fn test_grant_pauser_role() {
+    let contract = init_contract();
+
+    // Grant PAUSER_ROLE to pauser address
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify role was granted
+    assert(contract.has_this_role(PAUSER_ROLE, pauser()), 'Pauser role not granted');
+    assert(contract.get_this_role_member_count(PAUSER_ROLE) == 1, 'Wrong pauser count');
+}
+
+#[test]
+#[should_panic(expected: ('Caller is missing role',))]
+fn test_grant_role_unauthorized() {
+    let contract = init_contract();
+
+    // Try to grant role as unauthorized user
+    start_cheat_caller_address(contract.contract_address, unauthorized_user());
+    contract.grant_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin());
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+fn test_revoke_role() {
+    let contract = init_contract();
+
+    // First grant a role
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin());
+
+    // Verify granted
+    assert(
+        contract.has_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin()),
+        'Role not granted initially'
+    );
+    assert(contract.get_this_role_member_count(MARKETPLACE_ADMIN_ROLE) == 2, 'Wrong initial count');
+
+    // Revoke the role
+    contract.revoke_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify revoked
+    assert(
+        !contract.has_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin()), 'Role not revoked'
+    );
+    assert(contract.get_this_role_member_count(MARKETPLACE_ADMIN_ROLE) == 1, 'Wrong final count');
+}
+
+#[test]
+#[should_panic(expected: ('Cannot remove last admin',))]
+fn test_revoke_last_admin_protection() {
+    let contract = init_contract();
+
+    // Try to revoke the last admin role
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.revoke_this_role(DEFAULT_ADMIN_ROLE, admin_address());
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+fn test_renounce_role() {
+    let contract = init_contract();
+
+    // First grant a role to marketplace_admin
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify granted
+    assert(contract.has_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin()), 'Role not granted');
+
+    // Renounce the role as marketplace_admin
+    start_cheat_caller_address(contract.contract_address, marketplace_admin());
+    contract.renounce_this_role(MARKETPLACE_ADMIN_ROLE);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify renounced
+    assert(
+        !contract.has_this_role(MARKETPLACE_ADMIN_ROLE, marketplace_admin()), 'Role not renounced'
+    );
+}
+
+#[test]
+#[should_panic(expected: ('Cannot remove last admin',))]
+fn test_renounce_last_admin_protection() {
+    let contract = init_contract();
+
+    // Try to renounce the last admin role
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.renounce_this_role(DEFAULT_ADMIN_ROLE);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+////
+///  PAUSE/UNPAUSE FUNCTIONALITY TESTS
+///
+
+#[test]
+#[should_panic(expected: ('Marketplace paused',))]
+fn test_pause_marketplace() {
+    let contract = init_contract();
+
+    // Grant PAUSER_ROLE to pauser
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Pause marketplace as pauser
+    start_cheat_caller_address(contract.contract_address, pauser());
+    contract.pause_marketplace();
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to create listing - should fail
+    start_cheat_caller_address(contract.contract_address, seller());
+    contract
+        .create_listing(nft_contract(), 1_u256, 1000_u256, ListingType::FixedPrice(()), 3600_u64);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller is missing role',))]
+fn test_pause_marketplace_unauthorized() {
+    let contract = init_contract();
+
+    // Try to pause as unauthorized user
+    start_cheat_caller_address(contract.contract_address, unauthorized_user());
+    contract.pause_marketplace();
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+fn test_unpause_marketplace() {
+    let contract = init_contract();
+
+    // Grant PAUSER_ROLE to pauser
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Pause marketplace
+    start_cheat_caller_address(contract.contract_address, pauser());
+    contract.pause_marketplace();
+
+    // Unpause marketplace
+    contract.unpause_marketplace();
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Now create listing should work
+    start_cheat_caller_address(contract.contract_address, seller());
+    let listing_id = contract
+        .create_listing(nft_contract(), 1_u256, 1000_u256, ListingType::FixedPrice(()), 3600_u64);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify listing was created successfully
+    let listing = contract.get_listing(listing_id);
+    assert(listing.status == ListingStatus::Active(()), 'Listing should be active');
+}
+
+#[test]
+#[should_panic(expected: ('Marketplace paused',))]
+fn test_purchase_listing_when_paused() {
+    let contract = init_contract();
+
+    // Create a listing first
+    start_cheat_caller_address(contract.contract_address, seller());
+    let listing_id = contract
+        .create_listing(nft_contract(), 1_u256, 1000_u256, ListingType::FixedPrice(()), 3600_u64);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Grant PAUSER_ROLE and pause marketplace
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    start_cheat_caller_address(contract.contract_address, pauser());
+    contract.pause_marketplace();
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to purchase - should fail
+    start_cheat_caller_address(contract.contract_address, buyer());
+    contract.purchase_listing(listing_id);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+///
+///  MULTIPLE ADMIN MANAGEMENT TESTS
+///
+
+#[test]
+fn test_multiple_admins() {
+    let contract = init_contract();
+    let second_admin = contract_address_const::<77777>();
+
+    // Grant DEFAULT_ADMIN_ROLE to second admin
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(DEFAULT_ADMIN_ROLE, second_admin);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify both admins exist
+    assert(contract.has_this_role(DEFAULT_ADMIN_ROLE, admin_address()), 'First admin missing');
+    assert(contract.has_this_role(DEFAULT_ADMIN_ROLE, second_admin), 'Second admin missing');
+    assert(contract.get_this_role_member_count(DEFAULT_ADMIN_ROLE) == 2, 'Wrong admin count');
+
+    // Second admin should be able to grant roles
+    start_cheat_caller_address(contract.contract_address, second_admin);
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify role was granted by second admin
+    assert!(contract.has_this_role(PAUSER_ROLE, pauser()), "Role not granted by second admin");
+}
+
+#[test]
+fn test_remove_one_of_multiple_admins() {
+    let contract = init_contract();
+    let second_admin = contract_address_const::<77777>();
+
+    // Add second admin
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(DEFAULT_ADMIN_ROLE, second_admin);
+
+    // Now remove first admin (should work since there's still another admin)
+    contract.revoke_this_role(DEFAULT_ADMIN_ROLE, admin_address());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify first admin removed but second admin remains
+    assert(!contract.has_this_role(DEFAULT_ADMIN_ROLE, admin_address()), 'First admin not removed');
+    assert(contract.has_this_role(DEFAULT_ADMIN_ROLE, second_admin), 'Second admin missing');
+    assert(contract.get_this_role_member_count(DEFAULT_ADMIN_ROLE) == 1, 'Wrong admin count');
+}
+
+///
+///  ROLE MEMBER TRACKING TESTS
+///
+
+#[test]
+fn test_role_member_count_tracking() {
+    let contract = init_contract();
+
+    // Initially should have 1 admin
+    assert(
+        contract.get_this_role_member_count(DEFAULT_ADMIN_ROLE) == 1, 'Wrong initial admin count'
+    );
+    assert(contract.get_this_role_member_count(PAUSER_ROLE) == 0, 'Wrong initial pauser count');
+
+    // Add multiple pausers
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    contract.grant_this_role(PAUSER_ROLE, buyer());
+    contract.grant_this_role(PAUSER_ROLE, seller());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify counts
+    assert(
+        contract.get_this_role_member_count(PAUSER_ROLE) == 3, 'Wrong pauser count after grants'
+    );
+
+    // Remove one pauser
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.revoke_this_role(PAUSER_ROLE, buyer());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify count decreased
+    assert(
+        contract.get_this_role_member_count(PAUSER_ROLE) == 2, 'Wrong pauser count after revoke'
+    );
+}
+
+#[test]
+fn test_duplicate_role_prevention() {
+    let contract = init_contract();
+
+    // Grant role to same user twice
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    contract.grant_this_role(PAUSER_ROLE, pauser()); // Duplicate
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Should still only count as 1
+    assert(contract.get_this_role_member_count(PAUSER_ROLE) == 1, 'Duplicate role granted');
+    assert!(contract.has_this_role(PAUSER_ROLE, pauser()), "Role missing after duplicate grant");
+}
+
+///
+///  INTEGRATION TESTS
+///
+
+#[test]
+#[should_panic]
+fn test_normal_marketplace_operations_with_rbac() {
+    let contract = init_contract();
+
+    // Grant PAUSER_ROLE to pauser
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, pauser());
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Normal marketplace operations should still work
+    start_cheat_caller_address(contract.contract_address, seller());
+    let listing_id = contract
+        .create_listing(nft_contract(), 1_u256, 1000_u256, ListingType::FixedPrice(()), 3600_u64);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Purchase should work
+    start_cheat_caller_address(contract.contract_address, buyer());
+    contract.purchase_listing(listing_id);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Verify purchase
+    let listing = contract.get_listing(listing_id);
+    assert(listing.status == ListingStatus::Sold(()), 'Purchase failed');
+
+    // Pauser should be able to pause
+    start_cheat_caller_address(contract.contract_address, pauser());
+    contract.pause_marketplace();
+    stop_cheat_caller_address(contract.contract_address);
+
+    // New listings should fail when paused
+    start_cheat_caller_address(contract.contract_address, seller());
+
+    contract
+        .create_listing(nft_contract(), 2_u256, 2000_u256, ListingType::FixedPrice(()), 3600_u64);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+
+#[test]
+#[should_panic(expected: ('account is zero address',))]
+fn test_role_operations_zero_address() {
+    let contract = init_contract();
+
+    // Granting role to zero address
+    let zero_address = contract_address_const::<0>();
+    start_cheat_caller_address(contract.contract_address, admin_address());
+    contract.grant_this_role(PAUSER_ROLE, zero_address);
+    stop_cheat_caller_address(contract.contract_address);
 }


### PR DESCRIPTION
## Overview
Implemented a comprehensive Role-Based Access Control (RBAC) system for the Marketplace contract, moving beyond simple `onlyOwner` checks to provide granular permission management with proper safety mechanisms.

## Related Issue

- Closes #31 

## **Key Features**

### **Role Management Functions**
- ✅ `grant_this_role()` - Grant roles to accounts with proper authorization
- ✅ `revoke_this_role()` - Revoke roles from accounts with safety checks  
- ✅ `renounce_this_role()` - Allow accounts to voluntarily remove their own roles
- ✅ `has_this_role()` - Check if account possesses specific role
- ✅ `get_this_role_admin()` - Get admin role for a given role
- ✅ `get_this_role_member_count()` - Get number of accounts with specific role

### **Role Definitions**
```
DEFAULT_ADMIN_ROLE        // Master admin role (manages all other roles)
MARKETPLACE_ADMIN_ROLE    // Can manage marketplace settings and emergency actions
PAUSER_ROLE              // Can pause/unpause marketplace operations
```

### **Role Hierarchy**
- `DEFAULT_ADMIN_ROLE` → Manages all other roles (including itself)
- `MARKETPLACE_ADMIN_ROLE` → Managed by `DEFAULT_ADMIN_ROLE`
- `PAUSER_ROLE` → Managed by `DEFAULT_ADMIN_ROLE`

## **Safety Mechanisms**

### **Admin Lockout Prevention**
- **Last Admin Protection**: Prevents removal of the final admin
- **Member Tracking**: Custom tracking system for role members
- **Safety Checks**: All role removal operations check for minimum admin count

### **Marketplace Pause Functionality**
- **Pause/Unpause**: Only `PAUSER_ROLE` can pause marketplace operations
- **Operation Blocking**: Paused marketplace blocks `create_listing()` and `purchase_listing()`
- **Granular Control**: Different roles for different administrative functions

## **Technical Implementation**

### **Components Used**
- `AccessControlComponent` - Core RBAC functionality from OpenZeppelin
- `SRC5Component` - Interface introspection support

### **Storage Additions**
```cairo
role_members: Map<felt252, Vec<ContractAddress>>        // Role member tracking
member_active: Map<(felt252, ContractAddress), bool>   // Active member flags  
marketplace_paused: bool                               // Pause state
```

##  **Key Changes**

### **Constructor Updates**
- Initializes RBAC components
- Sets up role hierarchy
- Grants initial admin roles to deployer/owner
- Establishes role member tracking

### **Access Control Integration**
- Replaces owner-only checks with role-based permissions
- Maintains existing marketplace functionality
- Adds pause/unpause capabilities

### **Custom Tracking System**
- Tracks role members using Vec storage
- Uses flag-based system for efficient member management
- Provides accurate role member counting
- Supports safety mechanism requirements

## ✅ **Testing Coverage**

### **Core RBAC Functionality**
- [x] Initial admin role assignment
- [x] Role hierarchy verification  
- [x] Grant/revoke/renounce operations
- [x] Unauthorized access prevention

### **Safety Mechanisms**
- [x] Last admin protection
- [x] Multiple admin management
- [x] Role member count tracking
- [x] Duplicate role prevention

### **Pause Functionality**
- [x] Authorized pause/unpause operations
- [x] Marketplace operation blocking when paused
- [x] Unauthorized pause attempts blocked

### **Integration Tests**
- [x] Normal marketplace operations with RBAC
- [x] Role-based permission enforcement
- [x] Edge case handling